### PR TITLE
Add support for custom I2C SDA and SCL pins

### DIFF
--- a/Adafruit_HMC5883_U.cpp
+++ b/Adafruit_HMC5883_U.cpp
@@ -102,14 +102,14 @@ byte Adafruit_HMC5883_Unified::read8(byte address, byte reg) {
 /**************************************************************************/
 void Adafruit_HMC5883_Unified::read() {
   // Read the magnetometer
-  Wire.beginTransmission((byte)HMC5883_ADDRESS_MAG);
+  Wire.beginTransmission(HMC5883_ADDRESS_MAG);
 #if ARDUINO >= 100
   Wire.write(HMC5883_REGISTER_MAG_OUT_X_H_M);
 #else
   Wire.send(HMC5883_REGISTER_MAG_OUT_X_H_M);
 #endif
   Wire.endTransmission(false);
-  Wire.requestFrom((byte)HMC5883_ADDRESS_MAG, (byte)6, true);
+  Wire.requestFrom(HMC5883_ADDRESS_MAG, 6, 1);
 
 // Note high before low (different than accel)
 #if ARDUINO >= 100
@@ -159,9 +159,13 @@ Adafruit_HMC5883_Unified::Adafruit_HMC5883_Unified(int32_t sensorID) {
     @brief  Setups the HW
 */
 /**************************************************************************/
-bool Adafruit_HMC5883_Unified::begin() {
+bool Adafruit_HMC5883_Unified::begin(uint8_t sda, uint8_t scl) {
   // Enable I2C
-  Wire.begin();
+  if (sda != 0 && scl != 0) {
+    Wire.begin(sda, scl); // Initialize Wire with custom SDA and SCL pins if provided
+  } else {
+    Wire.begin(); // Initialize Wire with default pins if custom pins are not provided
+  }
 
   // Enable the magnetometer
   write8(HMC5883_ADDRESS_MAG, HMC5883_REGISTER_MAG_MR_REG_M, 0x00);

--- a/Adafruit_HMC5883_U.cpp
+++ b/Adafruit_HMC5883_U.cpp
@@ -164,7 +164,7 @@ bool Adafruit_HMC5883_Unified::begin(uint8_t sda, uint8_t scl) {
   if (sda != 0 && scl != 0) {
     Wire.begin(sda, scl); // Initialize Wire with custom SDA and SCL pins if provided
   } else {
-    Wire.begin(); // Initialize Wire with default pins if custom pins are not provided
+    Wire.begin(); // Initialize Wire with default pins if custom pins are not provided 
   }
 
   // Enable the magnetometer

--- a/Adafruit_HMC5883_U.h
+++ b/Adafruit_HMC5883_U.h
@@ -81,7 +81,7 @@ public:
    */
   Adafruit_HMC5883_Unified(int32_t sensorID = -1);
 
-  bool begin(uint8_t sda = 0, uint8_t scl = 0); //!< @return Returns whether connection was successful
+  bool begin(uint8_t sda = 0, uint8_t scl = 0); //!< @return Returns whether connection was successful 
   void setMagGain(hmc5883MagGain gain); //!< @param gain Desired magnetic gain
   bool
   getEvent(sensors_event_t *); //!< @return Returns the most recent sensor event

--- a/Adafruit_HMC5883_U.h
+++ b/Adafruit_HMC5883_U.h
@@ -81,7 +81,7 @@ public:
    */
   Adafruit_HMC5883_Unified(int32_t sensorID = -1);
 
-  bool begin(void); //!< @return Returns whether connection was successful
+  bool begin(uint8_t sda = 0, uint8_t scl = 0); //!< @return Returns whether connection was successful
   void setMagGain(hmc5883MagGain gain); //!< @param gain Desired magnetic gain
   bool
   getEvent(sensors_event_t *); //!< @return Returns the most recent sensor event

--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
-## This Fork ##
-
-Has support for custom SDA and SCL - use mag.begin(SDA_PIN, SCL_PIN) for custom pins, or use mag.begin() to use default Wire pins for your MCU
-
-Tested and Working on ESP32 (Wemos D1 Mini HW655 using multiple arrangments of pins 5, 16, 17, 18, 21, 22)
-
-
 # Adafruit HMC5883L Driver (3-Axis Magnetometer) [![Build Status](https://github.com/adafruit/Adafruit_HMC5883_Unified/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_HMC5883_Unified/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_HMC5883_Unified/html/index.html)
 
 This driver is for the Adafruit HMC5883L Breakout (http://www.adafruit.com/products/1746), and is based on Adafruit's Unified Sensor Library (Adafruit_Sensor).
+
+It supports the use of custom SDA and SCL pins. use `mag.begin(SDA_PIN, SCL_PIN)` for custom pins, or use `mag.begin()` to use default Wire pins for your MCU
 
 ## About the HMC5883 ##
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## This Fork ##
+
+has support for custom SDA and SCL - use mag.begin(SDA_PIN, SCL_PIN)
+
+Caution - builds, but DID NOT WORK on my ESP32 D1 on pish 16 and 17 :-(
+
+
 # Adafruit HMC5883L Driver (3-Axis Magnetometer) [![Build Status](https://github.com/adafruit/Adafruit_HMC5883_Unified/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_HMC5883_Unified/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_HMC5883_Unified/html/index.html)
 
 This driver is for the Adafruit HMC5883L Breakout (http://www.adafruit.com/products/1746), and is based on Adafruit's Unified Sensor Library (Adafruit_Sensor).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## This Fork ##
 
-has support for custom SDA and SCL - use mag.begin(SDA_PIN, SCL_PIN)
+Has support for custom SDA and SCL - use mag.begin(SDA_PIN, SCL_PIN) for custom pins, or use mag.begin() to use default Wire pins for your MCU
 
-Caution - builds, but DID NOT WORK on my ESP32 D1 on pish 16 and 17 :-(
+Tested and Working on ESP32 (Wemos D1 Mini HW655 using multiple arrangments of pins 5, 16, 17, 18, 21, 22)
 
 
 # Adafruit HMC5883L Driver (3-Axis Magnetometer) [![Build Status](https://github.com/adafruit/Adafruit_HMC5883_Unified/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_HMC5883_Unified/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_HMC5883_Unified/html/index.html)


### PR DESCRIPTION
**Describe the scope of your change--i.e. what the change does and what parts of the code were modified.**  

Added feature to let users specify custom SDA and SCL pins.

No breaking changes were made.  Existing code which does not specify any pins will run unchanged.

**Describe any known limitations with your change.** 

none known

**Please run any tests or examples that can exercise your modified code.** 

Tested and Working on ESP32 (Wemos D1 Mini HW655 using multiple arrangements of pins 5, 16, 17, 18, 21, 22)

NOTE1 - existing code was attempting to cast as (byte) arguments that were expected to be (int) within esp32 Wire lib
NOTE2 - existing code was attempting to pass "True" bool into (int) datatype within esp32 Wire lib
The above 2 issues were fixed to build this successfully on esp32

