### PR TITLE
Add clang-format CI job and format code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,8 +3,19 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run clang-format
+      uses: jidicula/clang-format-action@v4.14.0
+      with:
+        clang-format-version: '18'
+
   build:
     runs-on: ubuntu-latest
+    needs: clang-format
     
     steps:
     - uses: actions/setup-python@v4

--- a/Adafruit_HMC5883_U.cpp
+++ b/Adafruit_HMC5883_U.cpp
@@ -183,34 +183,34 @@ void Adafruit_HMC5883_Unified::setMagGain(hmc5883MagGain gain) {
   _magGain = gain;
 
   switch (gain) {
-  case HMC5883_MAGGAIN_1_3:
-    _hmc5883_Gauss_LSB_XY = 1100;
-    _hmc5883_Gauss_LSB_Z = 980;
-    break;
-  case HMC5883_MAGGAIN_1_9:
-    _hmc5883_Gauss_LSB_XY = 855;
-    _hmc5883_Gauss_LSB_Z = 760;
-    break;
-  case HMC5883_MAGGAIN_2_5:
-    _hmc5883_Gauss_LSB_XY = 670;
-    _hmc5883_Gauss_LSB_Z = 600;
-    break;
-  case HMC5883_MAGGAIN_4_0:
-    _hmc5883_Gauss_LSB_XY = 450;
-    _hmc5883_Gauss_LSB_Z = 400;
-    break;
-  case HMC5883_MAGGAIN_4_7:
-    _hmc5883_Gauss_LSB_XY = 400;
-    _hmc5883_Gauss_LSB_Z = 255;
-    break;
-  case HMC5883_MAGGAIN_5_6:
-    _hmc5883_Gauss_LSB_XY = 330;
-    _hmc5883_Gauss_LSB_Z = 295;
-    break;
-  case HMC5883_MAGGAIN_8_1:
-    _hmc5883_Gauss_LSB_XY = 230;
-    _hmc5883_Gauss_LSB_Z = 205;
-    break;
+    case HMC5883_MAGGAIN_1_3:
+      _hmc5883_Gauss_LSB_XY = 1100;
+      _hmc5883_Gauss_LSB_Z = 980;
+      break;
+    case HMC5883_MAGGAIN_1_9:
+      _hmc5883_Gauss_LSB_XY = 855;
+      _hmc5883_Gauss_LSB_Z = 760;
+      break;
+    case HMC5883_MAGGAIN_2_5:
+      _hmc5883_Gauss_LSB_XY = 670;
+      _hmc5883_Gauss_LSB_Z = 600;
+      break;
+    case HMC5883_MAGGAIN_4_0:
+      _hmc5883_Gauss_LSB_XY = 450;
+      _hmc5883_Gauss_LSB_Z = 400;
+      break;
+    case HMC5883_MAGGAIN_4_7:
+      _hmc5883_Gauss_LSB_XY = 400;
+      _hmc5883_Gauss_LSB_Z = 255;
+      break;
+    case HMC5883_MAGGAIN_5_6:
+      _hmc5883_Gauss_LSB_XY = 330;
+      _hmc5883_Gauss_LSB_Z = 295;
+      break;
+    case HMC5883_MAGGAIN_8_1:
+      _hmc5883_Gauss_LSB_XY = 230;
+      _hmc5883_Gauss_LSB_Z = 205;
+      break;
   }
 }
 
@@ -219,7 +219,7 @@ void Adafruit_HMC5883_Unified::setMagGain(hmc5883MagGain gain) {
     @brief  Gets the most recent sensor event
 */
 /**************************************************************************/
-bool Adafruit_HMC5883_Unified::getEvent(sensors_event_t *event) {
+bool Adafruit_HMC5883_Unified::getEvent(sensors_event_t* event) {
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
 
@@ -245,7 +245,7 @@ bool Adafruit_HMC5883_Unified::getEvent(sensors_event_t *event) {
     @brief  Gets the sensor_t data
 */
 /**************************************************************************/
-void Adafruit_HMC5883_Unified::getSensor(sensor_t *sensor) {
+void Adafruit_HMC5883_Unified::getSensor(sensor_t* sensor) {
   /* Clear the sensor_t object */
   memset(sensor, 0, sizeof(sensor_t));
 

--- a/Adafruit_HMC5883_U.h
+++ b/Adafruit_HMC5883_U.h
@@ -75,7 +75,7 @@ typedef struct hmc5883MagData_s {
 
 //! Unified sensor driver for the magnetometer ///
 class Adafruit_HMC5883_Unified : public Adafruit_Sensor {
-public:
+ public:
   /*!
    * @param sensorID sensor ID, -1 by default
    */
@@ -83,11 +83,11 @@ public:
 
   bool begin(void); //!< @return Returns whether connection was successful
   void setMagGain(hmc5883MagGain gain); //!< @param gain Desired magnetic gain
-  bool
-  getEvent(sensors_event_t *); //!< @return Returns the most recent sensor event
-  void getSensor(sensor_t *);
+  bool getEvent(
+      sensors_event_t*); //!< @return Returns the most recent sensor event
+  void getSensor(sensor_t*);
 
-private:
+ private:
   hmc5883MagGain _magGain;
   hmc5883MagData _magData; // Last read magnetometer data will be available here
   int32_t _sensorID;


### PR DESCRIPTION
This PR adds proper clang-format CI integration:

- Add separate `clang-format` job using `jidicula/clang-format-action@v4.14.0` with clang-format 18
- Build job now depends on clang-format job passing first  
- Add `.clang-format` configuration file
- Format all source files with clang-format

Tested with both clang-format-18 and clang-format-19.

cc @ladyada